### PR TITLE
fix: 修复Safari和Chrome浏览器底部控件显示问题

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,11 @@
             '--app-theme-color',
             appTheme,
           )
+
+          // 初始设置视口高度偏移量
+          const vh = window.innerHeight * 0.01
+          document.documentElement.style.setProperty('--vh-offset', `${(vh * 100) * 0.05}px`)
+          document.documentElement.style.setProperty('--vh', `${vh}px`)
         })()
       </script>
       <style>
@@ -35,7 +40,8 @@
         .first-loading-wrap {
           display: flex;
           width: 100%;
-          height: 100vh;
+          height: calc(100vh - var(--vh-offset, 0px));
+          height: 100dvh;
           justify-content: center;
           align-items: center;
           flex-direction: column;

--- a/src/layout/index.vue
+++ b/src/layout/index.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable prettier/prettier -->
 <template>
-  <div class="h-screen flex flex-col">
+  <div class="h-[calc(100vh-var(--vh-offset,0px))] h-[100dvh] flex flex-col">
     <van-nav-bar v-if="getShowHeader" placeholder fixed :title="getTitle" />
     <routerView class="flex-1 overflow-x-hidden">
       <template #default="{ Component, route }">

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,7 @@ import { createApp } from 'vue'
 import App from './App.vue'
 import router, { setupRouter } from './router'
 import { setupStore } from '@/store'
+import { setupViewportHeight } from '@/utils/viewportHeight'
 
 async function bootstrap() {
   const app = createApp(App)
@@ -21,6 +22,8 @@ async function bootstrap() {
   setupStore(app)
   // 挂载路由
   setupRouter(app)
+  // 设置视口高度处理
+  setupViewportHeight()
   await router.isReady()
   // 路由准备就绪后挂载APP实例
   app.mount('#app', true)

--- a/src/styles/var.less
+++ b/src/styles/var.less
@@ -2,3 +2,8 @@
 @primaryColor: #5d9dfe;
 @header-height: 46px;
 @footer-height: 50px;
+
+// 视口高度偏移量，用于移动端浏览器地址栏的处理
+:root {
+  --vh-offset: 0px;
+}

--- a/src/utils/viewportHeight.ts
+++ b/src/utils/viewportHeight.ts
@@ -1,0 +1,26 @@
+/**
+ * 处理移动端浏览器视口高度问题
+ */
+
+const supportsDvh = () => {
+  const div = document.createElement('div')
+  div.style.height = '100dvh'
+  return div.style.height === '100dvh'
+}
+
+export const setupViewportHeight = () => {
+  if (supportsDvh()) {
+    return
+  }
+
+  updateViewportHeight()
+
+  window.addEventListener('resize', updateViewportHeight)
+  window.addEventListener('orientationchange', updateViewportHeight)
+}
+
+const updateViewportHeight = () => {
+  const vh = window.innerHeight * 0.01
+  document.documentElement.style.setProperty('--vh-offset', `${(vh * 100) * 0.05}px`)
+  document.documentElement.style.setProperty('--vh', `${vh}px`)
+}


### PR DESCRIPTION
## 问题描述
在Safari和Chrome浏览器中，登录成功后底部的控件（tabbar）不显示，而在UC浏览器中可以正常显示。

## 解决方案
1. 使用dvh单位替换vh单位，以适应不同浏览器的动态视口高度
2. 为不支持dvh的浏览器提供降级方案，使用calc(100vh - var(--vh-offset))
3. 添加视口高度处理工具函数，动态计算和更新视口高度偏移量

## 修改内容
- 修改layout/index.vue中的高度单位
- 修改index.html中的加载动画容器高度
- 添加视口高度处理工具函数
- 在应用启动时初始化视口高度处理

## 相关issue
Closes #38